### PR TITLE
Use platform-independent path resolution for output

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,7 +110,7 @@ function render(file, data, outputDir) {
     if (err) return console.error(chalk.red(err))
     var outputFile = file.replace(/\.\w+$/, '') + '.html'
     if (outputDir) {
-      outputFile = outputDir + '\\' + outputFile
+      outputFile = path.resolve(outputDir, outputFile);
       mkdirp.sync(path.dirname(outputFile))
     }
     console.log(chalk.blue('Rendering: ' + file))


### PR DESCRIPTION
Hi, interesting timing with this new repo: I just had the need today to convert some templates to Nunjucks and found this app to use to basically lint the templates by compiling them and seeing if there were any errors.

I ran into a little bug that I fixed in this PR where the output path doesn't get set correctly on *nix systems because of the difference with path separators. This change lets Node handle that, so the code doesn't need to be concerned with that platform specific information.
