### PR TITLE
Add .gitattributes file to fix line ending problems

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto


### PR DESCRIPTION
Similar to [issue #75 for nw-builder](https://github.com/nwjs/nw-builder/issues/75), on there is encoding issues when the project is pulled down resulting in errors with `env: node\r: No such file or directory`.

This forces the project fetch to encode as plain-text which will resolve line encoding issues.
