### PR TITLE
Expose environment variables to render context.

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,6 +61,8 @@ var env = nunjucks.configure(path.resolve(process.cwd(), opts.dirIn), opts.nunju
 // Parse second argument as data context if any
 opts.context = (argv._[1]) ? JSON.parse(fs.readFileSync(argv._[1], 'utf8')) : {}
 
+opts.context.NODE_ENV = process.env.NODE_ENV;
+
 // Set glob options
 opts.glob = { 
   strict: true,

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ var env = nunjucks.configure(path.resolve(process.cwd(), opts.dirIn), opts.nunju
 // Parse second argument as data context if any
 opts.context = (argv._[1]) ? JSON.parse(fs.readFileSync(argv._[1], 'utf8')) : {}
 
-opts.context.NODE_ENV = process.env.NODE_ENV;
+opts.context.env = process.env;
 
 // Set glob options
 opts.glob = { 


### PR DESCRIPTION
While having the ability to provide a configuration object may work for most people, there may be instances when you want to render your templates differently depending upon certain environment variables being set or not.