### PR TITLE
Allow multiple paths to be specified.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-* text=auto
+* text eol=lf

--- a/index.js
+++ b/index.js
@@ -85,7 +85,11 @@ if (argv.watch) {
 
   opts.chokidar = {
     persistent: true,
-    cwd: path.resolve(process.cwd(), opts.dirIn)
+    cwd: path.resolve(process.cwd(), opts.dirIn),
+    awaitWriteFinish: {
+      stabilityThreshold: 300,
+      pollInterval: 50
+    }
   }
   var watcher = chokidar.watch(argv._[0], opts.chokidar)
   var layouts = []

--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ var argv = require('yargs')
 
 // Set defaults
 var opts = {}
-opts.dirIn = argv.path || ''
+opts.dirsIn = (argv.path instanceof Array) ? argv.path : [argv.path] || []
 opts.dirOut = argv.out || null
 opts.nunjucks = (argv.options) ? JSON.parse(fs.readFileSync(argv.options, 'utf8')) : {
   trimBlocks: true,
@@ -61,7 +61,11 @@ opts.nunjucks = (argv.options) ? JSON.parse(fs.readFileSync(argv.options, 'utf8'
 }
 
 // Set Nunjucks environnement
-var env = nunjucks.configure(path.resolve(process.cwd(), opts.dirIn), opts.nunjucks)
+var loaders = []
+for (var i = 0; i < opts.dirsIn.length; i++) {
+  loaders.push(new nunjucks.FileSystemLoader(path.resolve(process.cwd(), opts.dirsIn[i])))
+}
+var env = new nunjucks.Environment(loaders, opts.nunjucks)
 
 // Parse second argument as data context if any
 opts.context = (argv._[1]) ? JSON.parse(fs.readFileSync(argv._[1], 'utf8')) : {}
@@ -69,7 +73,7 @@ opts.context = (argv._[1]) ? JSON.parse(fs.readFileSync(argv._[1], 'utf8')) : {}
 // Set glob options
 opts.glob = {
   strict: true,
-  cwd: path.resolve(process.cwd(), opts.dirIn),
+  cwd: path.resolve(process.cwd(), opts.dirsIn[0]),
   ignore: '**/_*.*',
   nonull: true
 }
@@ -85,7 +89,7 @@ if (argv.watch) {
 
   opts.chokidar = {
     persistent: true,
-    cwd: path.resolve(process.cwd(), opts.dirIn),
+    cwd: path.resolve(process.cwd(), opts.dirsIn[0]),
     awaitWriteFinish: {
       stabilityThreshold: 300,
       pollInterval: 50

--- a/index.js
+++ b/index.js
@@ -40,6 +40,11 @@ var argv = require('yargs')
     nargs: 1,
     describe: 'Nunjucks options file'
   })
+  .option('unsafe', {
+    alias: 'u',
+    boolean: true,
+    describe: 'Allow use of .html as source files'
+  })
   .help()
   .alias('help', 'h')
   .epilogue('For more information on Nunjucks: https://mozilla.github.io/nunjucks/api.html')
@@ -62,7 +67,7 @@ var env = nunjucks.configure(path.resolve(process.cwd(), opts.dirIn), opts.nunju
 opts.context = (argv._[1]) ? JSON.parse(fs.readFileSync(argv._[1], 'utf8')) : {}
 
 // Set glob options
-opts.glob = { 
+opts.glob = {
   strict: true,
   cwd: path.resolve(process.cwd(), opts.dirIn),
   ignore: '**/_*.*',
@@ -70,8 +75,8 @@ opts.glob = {
 }
 
 // Match glob pattern and render files accordingly
-glob(argv._[0], opts.glob, function(err, files) { 
-  if (err) return console.error(chalk.red(err))  
+glob(argv._[0], opts.glob, function(err, files) {
+  if (err) return console.error(chalk.red(err))
   renderAll(files, opts.context, opts.dirOut)
 })
 
@@ -112,14 +117,14 @@ if (argv.watch) {
 
 // Render one file
 function render(file, data, outputDir) {
-  if (path.extname(file) === '.html')
-    return console.error(chalk.red('To avoid overwriting your templates, do not use html as file extension'))
+  if (!argv.unsafe && path.extname(file) === '.html')
+    return console.error(chalk.red(file + ': To use .html as source files, add --unsafe/-u flag'))
 
   env.render(file, data, function(err, res) {
     if (err) return console.error(chalk.red(err))
     var outputFile = file.replace(/\.\w+$/, '') + '.html'
     if (outputDir) {
-      outputFile = path.resolve(outputDir, outputFile);
+      outputFile = path.resolve(outputDir, outputFile)
       mkdirp.sync(path.dirname(outputFile))
     }
     console.log(chalk.blue('Rendering: ' + file))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nunjucks-cli",
-  "version": "0.4.9",
+  "version": "0.5.0",
   "description": "Nunjucks CLI wrapper and templates watcher",
   "main": "index.js",
   "preferGlobal": true,

--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ Compiles all `.tpl` files (including subdirectories), except the ones starting b
 ### `--path <directory>`
 `-p <directory>`
 
-Path where the templates live. Default to the current working directory.
+Path where the templates live. Default to the current working directory. Multiple path options may be specified.
 See https://mozilla.github.io/nunjucks/api.html#configure
 
 ### `--out <directory>`
@@ -26,7 +26,7 @@ Output directory.
 ### `--watch`
 `-w`
 
-Allows to keep track of file changes and render accordingly (except files starting by `_`).
+Allows to keep track of file changes and render accordingly (except files starting by `_`). Where multiple `--path` options are given, only the first path is watched.
 
 ### `--unsafe`
 `-u`

--- a/readme.md
+++ b/readme.md
@@ -28,10 +28,15 @@ Output directory.
 
 Allows to keep track of file changes and render accordingly (except files starting by `_`).
 
+### `--unsafe`
+`-u`
+
+Allows use of .html as source files extension.
+
 ### `--options <file>`
 `-O <file>`
 
-Takes a json file as Nunjucks options. Defaults are : 
+Takes a json file as Nunjucks options. Defaults are :
 
     trimBlocks: true,
     lstripBlocks: true,


### PR DESCRIPTION
Hi,

Thanks for creating nunjucks-cli. I have adjusted it slightly to fit my use case, which is that I want to compile a template in my CWD, but the template `extend`s another template that I keep in a separate directory which I use as a library of template files.

My solution is to use Nunjuck's facility for supporting multiple loaders, and to allow multiple `--path` arguments to be given to nunjucks-cli.

I hope you find this PR helpful, although perhaps the problem is too specific to my particular project to be of any use more widely. Also, I'm not a Nunjucks expert and maybe there is a problem with this approach that I'm not aware of.

Regards,

Alex
