### PR TITLE
Add noExtension flag which disables .html from being appended to output files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-* text=auto
+* text eol=lf

--- a/index.js
+++ b/index.js
@@ -85,7 +85,11 @@ if (argv.watch) {
 
   opts.chokidar = {
     persistent: true,
-    cwd: path.resolve(process.cwd(), opts.dirIn)
+    cwd: path.resolve(process.cwd(), opts.dirIn),
+    awaitWriteFinish: {
+      stabilityThreshold: 300,
+      pollInterval: 50
+    }
   }
   var watcher = chokidar.watch(argv._[0], opts.chokidar)
   var layouts = []

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ var argv = require('yargs')
     boolean: true,
     describe: 'Allow use of .html as source files'
   })
-  .option('noextension', {
+  .option('noExtension', {
     alias: 'e',
     boolean: true,
     describe: 'If enabled, do not add .html to compiled files'
@@ -132,7 +132,7 @@ function render(file, data, outputDir) {
   env.render(file, data, function(err, res) {
     if (err) return console.error(chalk.red(err))
     var outputFile = file.replace(/\.\w+$/, '')
-    if (!argv.opts.noextension) {
+    if (!argv.noExtension) {
       outputFile += '.html'
     }
     if (outputDir) {

--- a/index.js
+++ b/index.js
@@ -40,6 +40,11 @@ var argv = require('yargs')
     nargs: 1,
     describe: 'Nunjucks options file'
   })
+  .option('unsafe', {
+    alias: 'u',
+    boolean: true,
+    describe: 'Allow use of .html as source files'
+  })
   .help()
   .alias('help', 'h')
   .epilogue('For more information on Nunjucks: https://mozilla.github.io/nunjucks/api.html')
@@ -62,7 +67,7 @@ var env = nunjucks.configure(path.resolve(process.cwd(), opts.dirIn), opts.nunju
 opts.context = (argv._[1]) ? JSON.parse(fs.readFileSync(argv._[1], 'utf8')) : {}
 
 // Set glob options
-opts.glob = { 
+opts.glob = {
   strict: true,
   cwd: path.resolve(process.cwd(), opts.dirIn),
   ignore: '**/_*.*',
@@ -70,8 +75,8 @@ opts.glob = {
 }
 
 // Match glob pattern and render files accordingly
-glob(argv._[0], opts.glob, function(err, files) { 
-  if (err) return console.error(chalk.red(err))  
+glob(argv._[0], opts.glob, function(err, files) {
+  if (err) return console.error(chalk.red(err))
   renderAll(files, opts.context, opts.dirOut)
 })
 
@@ -112,14 +117,14 @@ if (argv.watch) {
 
 // Render one file
 function render(file, data, outputDir) {
-  if (path.extname(file) === '.html')
-    return console.error(chalk.red('To avoid overwriting your templates, do not use html as file extension'))
+  if (!argv.unsafe && path.extname(file) === '.html')
+    return console.error(chalk.red(file + ': To use .html as source files, add --unsafe/-u flag'))
 
   env.render(file, data, function(err, res) {
     if (err) return console.error(chalk.red(err))
     var outputFile = file.replace(/\.\w+$/, '') + '.html'
     if (outputDir) {
-      outputFile = path.resolve(outputDir, outputFile);
+      outputFile = path.resolve(outputDir, outputFile)
       mkdirp.sync(path.dirname(outputFile))
     }
     console.log(chalk.blue('Rendering: ' + file))

--- a/index.js
+++ b/index.js
@@ -45,6 +45,13 @@ var argv = require('yargs')
     boolean: true,
     describe: 'Allow use of .html as source files'
   })
+  .option('ext', {
+    alias: 'e',
+    string: true,
+    requiresArg: false,
+    nargs: 1,
+    describe: 'Optional extension to add to all output files (defaults to .html)'
+  })
   .help()
   .alias('help', 'h')
   .epilogue('For more information on Nunjucks: https://mozilla.github.io/nunjucks/api.html')
@@ -52,6 +59,7 @@ var argv = require('yargs')
 
 // Set defaults
 var opts = {}
+opts.ext = argv.ext || '.html'
 opts.dirIn = argv.path || ''
 opts.dirOut = argv.out || null
 opts.nunjucks = (argv.options) ? JSON.parse(fs.readFileSync(argv.options, 'utf8')) : {
@@ -126,7 +134,7 @@ function render(file, data, outputDir) {
 
   env.render(file, data, function(err, res) {
     if (err) return console.error(chalk.red(err))
-    var outputFile = file.replace(/\.\w+$/, '') + '.html'
+    var outputFile = file.replace(/\.\w+$/, '') + opts.ext
     if (outputDir) {
       outputFile = path.resolve(outputDir, outputFile)
       mkdirp.sync(path.dirname(outputFile))

--- a/index.js
+++ b/index.js
@@ -45,12 +45,10 @@ var argv = require('yargs')
     boolean: true,
     describe: 'Allow use of .html as source files'
   })
-  .option('ext', {
+  .option('noextension', {
     alias: 'e',
-    string: true,
-    requiresArg: false,
-    nargs: 1,
-    describe: 'Optional extension to add to all output files (defaults to .html)'
+    boolean: true,
+    describe: 'If enabled, do not add .html to compiled files'
   })
   .help()
   .alias('help', 'h')
@@ -59,7 +57,6 @@ var argv = require('yargs')
 
 // Set defaults
 var opts = {}
-opts.ext = argv.ext || '.html'
 opts.dirIn = argv.path || ''
 opts.dirOut = argv.out || null
 opts.nunjucks = (argv.options) ? JSON.parse(fs.readFileSync(argv.options, 'utf8')) : {
@@ -134,7 +131,10 @@ function render(file, data, outputDir) {
 
   env.render(file, data, function(err, res) {
     if (err) return console.error(chalk.red(err))
-    var outputFile = file.replace(/\.\w+$/, '') + opts.ext
+    var outputFile = file.replace(/\.\w+$/, '')
+    if (!argv.opts.noextension) {
+      outputFile += '.html'
+    }
     if (outputDir) {
       outputFile = path.resolve(outputDir, outputFile)
       mkdirp.sync(path.dirname(outputFile))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nunjucks-cli",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Nunjucks CLI wrapper and templates watcher",
   "main": "index.js",
   "preferGlobal": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nunjucks-cli",
-  "version": "0.4.9",
+  "version": "0.5.0",
   "description": "Nunjucks CLI wrapper and templates watcher",
   "main": "index.js",
   "preferGlobal": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nunjucks-cli",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Nunjucks CLI wrapper and templates watcher",
   "main": "index.js",
   "preferGlobal": true,

--- a/readme.md
+++ b/readme.md
@@ -28,10 +28,15 @@ Output directory.
 
 Allows to keep track of file changes and render accordingly (except files starting by `_`).
 
+### `--unsafe`
+`-u`
+
+Allows use of .html as source files extension.
+
 ### `--options <file>`
 `-O <file>`
 
-Takes a json file as Nunjucks options. Defaults are : 
+Takes a json file as Nunjucks options. Defaults are :
 
     trimBlocks: true,
     lstripBlocks: true,

--- a/readme.md
+++ b/readme.md
@@ -41,8 +41,11 @@ Takes a json file as Nunjucks options. Defaults are :
     trimBlocks: true,
     lstripBlocks: true,
     noCache: true
+    
+### `--noextension`
+`-e`
 
-See https://mozilla.github.io/nunjucks/api.html#configure
+If enabled, do not add .html to output files.
 
 #### Advanced examples
 

--- a/readme.md
+++ b/readme.md
@@ -42,6 +42,8 @@ Takes a json file as Nunjucks options. Defaults are :
     lstripBlocks: true,
     noCache: true
     
+-See https://mozilla.github.io/nunjucks/api.html#configure
+    
 ### `--noextension`
 `-e`
 


### PR DESCRIPTION
I wanted to use this package to compile templates not for .html files 

For my use case, I am compiling nginx config files for some devops stuff, and not adding a .html extension is useful to me (I imagine it would be useful for others too)

I will use my own fork for now, but here's a PR in case you would like to merge in 