### PR TITLE
Add logging of output file location

### DIFF
--- a/main.js
+++ b/main.js
@@ -74,12 +74,14 @@ const render = (/** @type {string[]} */ files) => {
 
 		let outputFile = file.replace(/\.\w+$/, `.${argv.extension}`)
 
+		console.log(chalk.blue('Rendering: ' + file))
+		console.log(chalk.blue('       as: ' + outputFile))
+
 		if (outputDir) {
 			outputFile = resolve(outputDir, outputFile)
 			mkdirp.sync(dirname(outputFile))
 		}
 
-		console.log(chalk.blue('Rendering: ' + file))
 		writeFileSync(outputFile, res)
 	}
 }


### PR DESCRIPTION
It's useful to be able to see where the template is rendered to, especially if the output directory is different is to the template directory.

This PR just makes a simple tweak to the output message to include the path of the output file (before path resolution).