### PR TITLE
Add directory templating feature to nunjucks-cli

### DIFF
--- a/fixtures/first.tpl
+++ b/fixtures/first.tpl
@@ -1,5 +1,5 @@
 {% extends "_layout.tpl" %}
 {% block main %}
   <h1>First Template</h1>
-  <p>{{ a }}</p>
+  <p>${{ a }}</p>
 {% endblock %}

--- a/fixtures/second.tpl
+++ b/fixtures/second.tpl
@@ -1,5 +1,5 @@
 {% extends "_layout.tpl" %}
 {% block main %}
   <h1>Second template</h1>
-  <p>{{ env.NODE_ENV }}</p>
+  <p>${{ env.NODE_ENV }}</p>
 {% endblock %}

--- a/main.js
+++ b/main.js
@@ -1,17 +1,21 @@
 #! /usr/bin/env node
-const { readdirSync, readFileSync, writeFileSync, statSync } = require('fs')
-const { resolve, basename, dirname } = require('path')
-const nunjucks = require('nunjucks')
-const chokidar = require('chokidar')
-const mkdirp = require('mkdirp')
-const chalk = require('chalk')
-
+const { readdirSync, readFileSync, writeFileSync, statSync } = require('fs');
+const { resolve, basename, dirname } = require('path');
+const nunjucks = require('nunjucks');
+const chokidar = require('chokidar');
+const mkdirp = require('mkdirp');
+const chalk = require('chalk');
 
 const { argv } = require('yargs')
 	.usage('Usage: nunjucks <file|glob> [context] [options]')
 	.example('nunjucks foo.tpl data.json', 'Compile foo.tpl to foo.html')
-	.example('nunjucks *.tpl -w -p src -o dist', 'Watch .tpl files in ./src, compile them to ./dist')
-	.epilogue('For more information on Nunjucks: https://mozilla.github.io/nunjucks/')
+	.example(
+		'nunjucks *.tpl -w -p src -o dist',
+		'Watch .tpl files in ./src, compile them to ./dist',
+	)
+	.epilogue(
+		'For more information on Nunjucks: https://mozilla.github.io/nunjucks/',
+	)
 	.help()
 	.alias('help', 'h')
 	.locale('en')
@@ -22,7 +26,7 @@ const { argv } = require('yargs')
 		requiresArg: true,
 		nargs: 1,
 		describe: 'Path where templates live, defaults to .',
-		default: "."
+		default: '.',
 	})
 	.option('out', {
 		alias: 'o',
@@ -31,7 +35,7 @@ const { argv } = require('yargs')
 		nargs: 1,
 		describe: 'Output folder, defaults to rendered',
 		required: true,
-		default: "rendered"
+		default: 'rendered',
 	})
 	.option('watch', {
 		alias: 'w',
@@ -51,77 +55,79 @@ const { argv } = require('yargs')
 		requiresArg: true,
 		nargs: 1,
 		describe: 'Nunjucks values file',
-	})
+	});
 
-const inputDir = resolve(process.cwd(), argv.path) || ''
-const outputDir = argv.out
-
-const context = argv.data ? JSON.parse(readFileSync(argv.data, 'utf8')) : {}
+const context = argv.data ? JSON.parse(readFileSync(argv.data, 'utf8')) : {};
+const inputDir = resolve(process.cwd(), argv.path) || '';
+const outputDir = argv.out;
 // Expose environment variables to render context
-context.env = process.env
+context.env = process.env;
 
 /** @type {nunjucks.ConfigureOptions} */
 const nunjucksOptions = argv.options
 	? JSON.parse(readFileSync(argv.options, 'utf8'))
 	: {
-		"tags": {
-			"variableStart": "${{",
-			"variableEnd": "}}"
-		},
-		"autoescape": false
-	}
+			tags: {
+				variableStart: '${{',
+				variableEnd: '}}',
+			},
+			autoescape: false,
+	  };
 
-const nunjucksEnv = nunjucks.configure(inputDir, nunjucksOptions)
-
+const nunjucksEnv = nunjucks.configure(inputDir, nunjucksOptions);
+function interpolate(str, values) {
+	return str.replace(/\$\{\{([^\{]+)\}\}/g, function (_, ref) {
+		return eval(ref);
+	});
+}
 const render = (/** @type {string[]} */ files) => {
 	for (const file of files) {
-		const inputFile = resolve(file)
-		const res = nunjucksEnv.render(inputFile, context)
-		outputFile = resolve(outputDir, file)
-		mkdirp.sync(dirname(outputFile))
-
-		console.log(chalk.blue('Rendering: ' + file))
-		writeFileSync(outputFile, res)
+		let inputFile = resolve(file);
+		const res = nunjucksEnv.render(inputFile, context);
+		outputFile = resolve(outputDir, file);
+		let newOutputFile = interpolate(outputFile, context.values);
+		mkdirp.sync(dirname(newOutputFile));
+		writeFileSync(newOutputFile, res);
 	}
-}
+};
+const files = getFiles(argv.path);
 
-const files = getFiles(argv.path)
-render(files)
+render(files);
 
 // Watcher
 if (argv.watch) {
-	const layouts = []
-	const templates = []
+	const layouts = [];
+	const templates = [];
 
 	/** @type {chokidar.WatchOptions} */
-	const watchOptions = { persistent: true, cwd: inputDir }
-	const watcher = chokidar.watch(argv._[0], watchOptions)
+	const watchOptions = { persistent: true, cwd: inputDir };
+	const watcher = chokidar.watch(argv._[0], watchOptions);
 
-	watcher.on('ready', () => console.log(chalk.gray('Watching templates...')))
+	watcher.on('ready', () => console.log(chalk.gray('Watching templates...')));
 
 	// Sort files to not render partials/layouts
 	watcher.on('add', (file) => {
-		if (basename(file).indexOf('_') === 0) layouts.push(file)
-		else templates.push(file)
-	})
+		if (basename(file).indexOf('_') === 0) layouts.push(file);
+		else templates.push(file);
+	});
 
 	// if the file is a layout/partial, render all other files instead
 	watcher.on('change', (file) => {
-		if (layouts.indexOf(file) > -1) render(templates)
-		else render([file])
-	})
+		if (layouts.indexOf(file) > -1) render(templates);
+		else render([file]);
+	});
 }
 
-function getFiles (dir, files_){
-    files_ = files_ || [];
-    var files = readdirSync(dir);
-    for (var i in files){
-        var name = dir + '/' + files[i];
-        if (statSync(name).isDirectory()){
-            getFiles(name, files_);
-        } else {
-            files_.push(name);
-        }
-    }
-    return files_;
+function getFiles(dir, files_) {
+	files_ = files_ || [];
+	var files = readdirSync(dir);
+	for (var i in files) {
+		var name = dir + '/' + files[i];
+		if (statSync(name).isDirectory()) {
+			getFiles(name, files_);
+		} else {
+			files_.push(name);
+		}
+	}
+	return files_;
 }

--- a/package.json
+++ b/package.json
@@ -27,11 +27,12 @@
 		"test": "node test.js"
 	},
 	"dependencies": {
-		"chalk": "^2.4.2",
-		"chokidar": "^3.0.1",
-		"glob": "^7.0.3",
-		"mkdirp": "^0.5.1",
-		"nunjucks": "^3.2.0",
-		"yargs": "^13.2.4"
+		"chalk": "^4.1.2",
+		"chokidar": "^3.5.2",
+		"glob": "^7.1.7",
+		"mkdirp": "^1.0.4",
+		"nunjucks": "^3.2.3",
+		"yargs": "^17.1.1",
+		"walk": "2.3.14"
 	}
 }


### PR DESCRIPTION
CLI Nunjucks (which works with Backstage templates) does not allow to templatize disk paths.

We want to be able to use templates for directory names.